### PR TITLE
Made CampaignRenderer transient to allow removing this mod from a savegame

### DIFF
--- a/src/ssms/controller/SSMSControllerModPluginEx.java
+++ b/src/ssms/controller/SSMSControllerModPluginEx.java
@@ -269,7 +269,8 @@ public final class SSMSControllerModPluginEx extends BaseModPlugin {
     public void onGameLoad(boolean newGame) {
         InputScreenManager.getInstance().transitionToScreen(CampaignTransitionUI.ID);
         Global.getSector().addTransientScript(new CampaignControllerListener());
-        Global.getSector().getListenerManager().addListener(new CampaignRenderer());
+        Global.getSector().getListenerManager().removeListenerOfClass(CampaignRenderer.class); //remove non-transient listener, if one exists
+        Global.getSector().getListenerManager().addListener(new CampaignRenderer(), true);
     }
 
     @NotNull


### PR DESCRIPTION
Without this change, a reference to CampaignRenderer is added to the save file, and it cannot be loaded without this mod.
Attempting to load such a save without this mod produces the following exception:

> ---- Debugging information ----
cause-exception     : com.thoughtworks.xstream.mapper.CannotResolveClassException
cause-message       : ssms.controller.campaign.CampaignRenderer
class               : java.util.ArrayList
required-type       : java.util.ArrayList
converter-type      : com.thoughtworks.xstream.converters.collections.CollectionConverter
line number         : 339922
class[1]            : com.fs.util.container.repo.ObjectRepository
converter-type[1]   : com.thoughtworks.xstream.converters.reflection.ReflectionConverter
class[2]            : com.fs.starfarer.campaign.ListenerManager
class[3]            : com.fs.starfarer.campaign.CampaignEngine
converter-type[2]   : com.fs.starfarer.campaign.save.O
version             : not available